### PR TITLE
Add voice-driven window controls

### DIFF
--- a/KinectMouseController_NoNear/KinectMouseController_NoNear.csproj
+++ b/KinectMouseController_NoNear/KinectMouseController_NoNear.csproj
@@ -47,6 +47,7 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
+    <Reference Include="System.Speech" />
     <Reference Include="System.Xaml" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
@@ -65,6 +66,8 @@
     <Compile Include="Events.cs" />
     <Compile Include="InputInjector.cs" />
     <Compile Include="KinectMouseService.cs" />
+    <Compile Include="VoiceCommandService.cs" />
+    <Compile Include="WindowControl.cs" />
     <Compile Include="MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>
     </Compile>

--- a/KinectMouseController_NoNear/MainWindow.xaml.cs
+++ b/KinectMouseController_NoNear/MainWindow.xaml.cs
@@ -11,6 +11,7 @@ namespace KinectMouseController_NoNear
     public partial class MainWindow : Window
     {
         private KinectMouseService _svc = new KinectMouseService();
+        private VoiceCommandService _voice;
         private WriteableBitmap _colorBitmap;
         private byte[] _colorPixels;
         private bool _controlEnabled = true;
@@ -25,12 +26,17 @@ namespace KinectMouseController_NoNear
             _svc.ColorFrameArrived += OnColorFrame;
             _svc.HandDataUpdated += OnHandDataUpdated;
             _svc.Start();
+
+            _voice = new VoiceCommandService();
+            _voice.Start();
+
             SetupCursorVisual();
         }
 
         private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
         {
             _svc.Dispose();
+            _voice?.Dispose();
         }
 
         private void Window_KeyDown(object sender, KeyEventArgs e)

--- a/KinectMouseController_NoNear/VoiceCommandService.cs
+++ b/KinectMouseController_NoNear/VoiceCommandService.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Speech.Recognition;
+
+namespace KinectMouseController_NoNear
+{
+    public class VoiceCommandService : IDisposable
+    {
+        private readonly SpeechRecognitionEngine _recognizer;
+
+        public VoiceCommandService()
+        {
+            _recognizer = new SpeechRecognitionEngine();
+            var choices = new Choices("minimize window", "maximize window", "close window");
+            var gb = new GrammarBuilder(choices);
+            var grammar = new Grammar(gb);
+            _recognizer.LoadGrammar(grammar);
+            _recognizer.SpeechRecognized += OnSpeechRecognized;
+        }
+
+        public void Start()
+        {
+            _recognizer.SetInputToDefaultAudioDevice();
+            _recognizer.RecognizeAsync(RecognizeMode.Multiple);
+        }
+
+        public void Stop()
+        {
+            _recognizer.RecognizeAsyncStop();
+        }
+
+        private void OnSpeechRecognized(object sender, SpeechRecognizedEventArgs e)
+        {
+            if (e.Result.Confidence < 0.8)
+            {
+                return;
+            }
+
+            switch (e.Result.Text.ToLowerInvariant())
+            {
+                case "minimize window":
+                    WindowControl.MinimizeActiveWindow();
+                    break;
+                case "maximize window":
+                    WindowControl.MaximizeActiveWindow();
+                    break;
+                case "close window":
+                    WindowControl.CloseActiveWindow();
+                    break;
+            }
+        }
+
+        public void Dispose()
+        {
+            Stop();
+            _recognizer.Dispose();
+        }
+    }
+}

--- a/KinectMouseController_NoNear/WindowControl.cs
+++ b/KinectMouseController_NoNear/WindowControl.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace KinectMouseController_NoNear
+{
+    internal static class WindowControl
+    {
+        private const int SW_MINIMIZE = 6;
+        private const int SW_MAXIMIZE = 3;
+        private const uint WM_CLOSE = 0x0010;
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr GetForegroundWindow();
+
+        [DllImport("user32.dll")]
+        private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+        [DllImport("user32.dll")]
+        private static extern bool PostMessage(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+
+        public static void MinimizeActiveWindow()
+        {
+            var hWnd = GetForegroundWindow();
+            if (hWnd != IntPtr.Zero)
+            {
+                ShowWindow(hWnd, SW_MINIMIZE);
+            }
+        }
+
+        public static void MaximizeActiveWindow()
+        {
+            var hWnd = GetForegroundWindow();
+            if (hWnd != IntPtr.Zero)
+            {
+                ShowWindow(hWnd, SW_MAXIMIZE);
+            }
+        }
+
+        public static void CloseActiveWindow()
+        {
+            var hWnd = GetForegroundWindow();
+            if (hWnd != IntPtr.Zero)
+            {
+                PostMessage(hWnd, WM_CLOSE, IntPtr.Zero, IntPtr.Zero);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `WindowControl` utility with P/Invoke to minimize, maximize, or close the foreground window.
- Introduce `VoiceCommandService` using `System.Speech` to trigger window actions on recognized voice commands.
- Start the voice command service in `MainWindow` and update project references.

## Testing
- `dotnet build KinectMouseController_NoNear/KinectMouseController_NoNear.csproj` *(fails: command not found)*
- `msbuild KinectMouseController_NoNear/KinectMouseController_NoNear.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890f50d19fc83298b8b52215e62e50b